### PR TITLE
add --mem-per-cpu=0 option to srun used to start interactive job (qsub -I) (HPC-7403)

### DIFF
--- a/files/qsub.pl
+++ b/files/qsub.pl
@@ -293,7 +293,7 @@ sub make_command
     if ($interactive || $fake) {
         $mode |= INTERACTIVE;
         @command = (which(SALLOC));
-        @intcommand = (which('srun'), '--pty');
+        @intcommand = (which('srun'), '--pty', '--mem-per-cpu=0');
         $defaults->{J} = "INTERACTIVE" if exists($defaults->{J});
         $defaults->{'cpu-bind'} = 'v,none';
 

--- a/files/t/qsub-commands.t
+++ b/files/t/qsub-commands.t
@@ -117,7 +117,7 @@ is(join(" ", @$newcommand), $txt, "expected command after parse_script without e
 @ARGV = ('-I', '-l', 'nodes=2:ppn=4', '-l', 'vmem=2gb');
 ($mode, $command, $block, $script, $script_args, $defaults) = make_command($submitfilter);
 diag "interactive command @$command default ", explain $defaults;
-$txt = "$dba --mem=2048M srun --pty";
+$txt = "$dba --mem=2048M srun --pty --mem-per-cpu=0";
 is(join(" ", @$command), "$salloc $txt", "expected command for interactive");
 $script =~ s#^/usr##;
 is($script, '/bin/bash', "interactive script value is the bash shell command");

--- a/slurm-torque-wrappers.spec
+++ b/slurm-torque-wrappers.spec
@@ -14,7 +14,7 @@
 
 Summary: Slurm wrappers scripts with torque 6 support
 Name: slurm-torque-wrappers
-Version: 0.2
+Version: 0.2.1
 Release: 1
 
 Group: Applications/System


### PR DESCRIPTION
`--mem-per-cpu=0` is required to avoid that `srun` uses all the available memory, which results in MPI commands that run in the interactive session to hang

Tested, works like a charm.

cfr. https://bugs.schedmd.com/show_bug.cgi?id=6031