### PR TITLE
Fix issues HPC-7549

### DIFF
--- a/files/qsub.pl
+++ b/files/qsub.pl
@@ -565,7 +565,7 @@ sub parse_script
         # mixed with otehr opts etc etc
         foreach my $pbsopt (qw(e j o N)) {
             my $opts = $map{$pbsopt} || [$pbsopt];
-            my $pat = '^\s*#PBS.*?\s-'.$pbsopt.'\s+(\S*)\s*';
+            my $pat = '^\s*#PBS.*?\s-'.$pbsopt.'\s+(\S+)\s*';
             if ($line =~ m/$pat/) {
                 foreach my $opt (@$opts) {
                     $set{$opt} = $1
@@ -575,7 +575,7 @@ sub parse_script
     };
     # if -j PBS dircetive in the script,
     # do not use default error path for slurm
-    my @check_eo = ('e', 'o');
+    my @check_eo = qw(e o);
     if ($set{'j'}) {
         delete $defaults->{e};
         @check_eo = ('o');
@@ -590,7 +590,7 @@ sub parse_script
                 if (-d $set{$dir}) {
                     my $fname = $defaults->{$dir};
                     $fname =~s /\S*(\/\S*)/$1/s;
-                    push(@cmd, ("-".$dir, $set{$dir} . $fname ));
+                    push(@cmd, ("-$dir", $set{$dir} . $fname ));
                 }
             }
         }

--- a/files/qsub.pl
+++ b/files/qsub.pl
@@ -585,10 +585,12 @@ sub parse_script
     # if yes, the set the path for slurm.
     foreach my $dir (@check_eo) {
         unless (grep  (/^-$dir$/, @cmd)) {
-            if (-d $set{$dir}) {
-                my $fname = $defaults->{$dir};
-                $fname =~s /\S*(\/\S*)/$1/s;
-                push(@cmd, ("-".$dir, $set{$dir} . $fname ));
+            if ($set{$dir}) {
+                if (-d $set{$dir}) {
+                    my $fname = $defaults->{$dir};
+                    $fname =~s /\S*(\/\S*)/$1/s;
+                    push(@cmd, ("-".$dir, $set{$dir} . $fname ));
+                }
             }
         }
     }

--- a/files/qsub.pl
+++ b/files/qsub.pl
@@ -573,7 +573,7 @@ sub parse_script
             }
         }
     };
-    # if -j PBS dircetive in the script,
+    # if -j PBS directive is in the script,
     # do not use default error path for slurm
     my @check_eo = qw(e o);
     if ($set{'j'}) {

--- a/files/qsub.pl
+++ b/files/qsub.pl
@@ -581,6 +581,7 @@ sub parse_script
         @check_eo = ('o');
     }
     
+    # Mixing -j/-o/-e arguments and directives currently might lead to undesired behavior
     # check wheter the -o and -e directives are directory
     # if yes, the set the path for slurm.
     foreach my $dir (@check_eo) {

--- a/files/t/qsub-commands.t
+++ b/files/t/qsub-commands.t
@@ -35,8 +35,8 @@ my @da = qw(script arg1 -l nodes=2:ppn=4);
 my $dba = "--nodes=2 --ntasks=8 --ntasks-per-node=4";
 # defaults
 my $defs = {
-    e => getcwd . '/%j.e%A',
-    o => getcwd . '/%j.o%A',
+    e => getcwd . '/%x.e%A',
+    o => getcwd . '/%x.o%A',
     J => 'script',
     export => 'NONE',
     'get-user-env' => '60L',
@@ -98,7 +98,7 @@ my $txt = "$sbatch $dba";
 is(join(" ", @$command), $txt, "expected command for submitfilter");
 
 # no match
-$txt .= " -J script --chdir=$ENV{HOME} -e ".getcwd."/%j.e%A --export=NONE --get-user-env=60L -o ".getcwd."/%j.o%A";
+$txt .= " -J script --chdir=$ENV{HOME} -e ".getcwd."/%x.e%A --export=NONE --get-user-env=60L -o ".getcwd."/%x.o%A";
 my ($newtxt, $newcommand) = parse_script('', $command, $defaults);
 is(join(" ", @$newcommand), $txt, "expected command after parse_script without eo");
 

--- a/files/t/qsub-commands.t
+++ b/files/t/qsub-commands.t
@@ -174,17 +174,18 @@ sub pst
 my $stdin = "#\n#PBS -j oe\ncmd\n";
 $txt = " -e ";
 $cmdstr = pst($stdin);
-ok(index($cmdstr, $txt) == -1, "With -j directive, \"$txt\" argument should not be in: $cmdstr");
+is(index($cmdstr, $txt), -1, "With -j directive, \"$txt\" argument should not be in: $cmdstr");
 
 $stdin = "#\n#PBS -e .\n#PBS -o output\ncmd\n";
 $txt = "-e " . getcwd . "/./%";
 $cmdstr = pst($stdin);
-ok(index($cmdstr, $txt) != -1, "If -e directive is a directory, \"$txt\" argument should be in: $cmdstr");
+isnt(index($cmdstr, $txt), -1, "If -e directive is a directory, \"$txt\" argument should be in: $cmdstr");
 
 $stdin = "#\n#PBS -o .\n#PBS -j oe\ncmd\n";
 $txt = "-o " . getcwd . "/./%";
 my $txt2 = " -e ";
 $cmdstr = pst($stdin);
-ok(index($cmdstr, $txt) != -1 && index($cmdstr, $txt2) == -1, "If -o directive is a directory and -j directive is present, \"$txt\" argument should be and \"$txt2\" argument should not be in: $cmdstr");
+isnt(index($cmdstr, $txt), -1, "If -o directive is a directory and -j directive is present, \"$txt\" argument should be in: $cmdstr");
+is(index($cmdstr, $txt2), -1, "If -o directive is a directory and -j directive is present, \"$txt2\" argument should not be in: $cmdstr");
 
 done_testing();


### PR DESCRIPTION
If `-e`, `-o`, and `-j` options are directives are mixed, the wrapper might pass multiple `-e` and/or `-o` options to slurm, and in this case the option arguments might be wrong)

if `-o` or/and `-e` directives are directory (and it exists on the login node), then the wrapper adds the right arguments to slurm to put the output/error to that directory with the standard names. If one wants to check whether the directory exist on the worker node, then the pbs plugin for slurm have to be changed.